### PR TITLE
Add an action to register events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# TODO: Make it possible to change the pipectl verion
+FROM gcr.io/pipecd/pipectl:v0.9.14
+
+COPY register-event.sh /register-event.sh
+
+RUN chmod +x /register-event.sh
+
+ENTRYPOINT ["/register-event.sh"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # actions-event-register
 A GitHub action for registering Events to PipeCD
+
+## Inputs
+
+### `api-address`
+
+**Required**: gRPC address to the PipeCD api server.
+
+### `api-key`
+
+**Required**: API key to which the READ_WRITE role is attached.
+
+### `event-name`
+
+**Required**: The name of Event.
+
+### `data`
+
+**Required**: The string value of event data.
+
+### `labels`
+
+**Optional**: The comma-separated list of labels for the event. Format: key=value,key2=value2
+
+## Example usage
+
+```yaml
+# .github/workflows/register-event.yml
+name: "Register an event on PipeCD"
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  comment-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: pipe-cd/actions-event-register@v1.0
+      with:
+        api-address: ${{ secrets.PIPECD_API_ADDRESS }}
+        api-key: ${{ secrets.PIPECD_API_KEY }}
+        event-name: image-update
+        labels: app=foo,env=dev
+        data: $GITHUB_REF
+```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,32 @@
+name: 'Register event'
+description: 'Register an event to PipeCD'
+inputs:
+  api-address:
+    description: 'gRPC address to the PipeCD api server'
+    required: true
+    default: ''
+  api-key:
+    description: 'API key to which the READ_WRITE role is attached'
+    required: true
+    default: ''
+  event-name:
+    description: 'The name of Event'
+    required: true
+    default: ''
+  data:
+    description: 'The string value of event data'
+    required: true
+    default: ''
+  labels:
+    description: 'The comma-separated list of labels for the event. Format: key=value,key2=value2'
+    required: false
+    default: ''
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.api-address }}
+    - ${{ inputs.api-key }}
+    - ${{ inputs.event-name }}
+    - ${{ inputs.data }}
+    - ${{ inputs.labels }}

--- a/register-event.sh
+++ b/register-event.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -l
+
+export PATH=$PATH:/app/cmd/pipectl
+
+if [ -z "$5" ]
+then
+    pipectl event register \
+        --address=$1 \
+        --api-key=$2 \
+        --name=$3 \
+        --data=$4
+else
+    pipectl event register \
+        --address=$1 \
+        --api-key=$2 \
+        --name=$3 \
+        --data=$4 \
+        --labels=$5
+fi


### PR DESCRIPTION
It's obviously enough to run a shell script, that's why I settled on building a Docker container action according to [this guide](https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action)

Once got merged, I'm going to add a version tag for releases of this action:

```
git tag -a -m "My first action release" v1
git push --follow-tags
```

Later, looking to debug carefully.